### PR TITLE
Update OpenRouter API base URL

### DIFF
--- a/apps/extension/src/core/llm/openrouter.ts
+++ b/apps/extension/src/core/llm/openrouter.ts
@@ -15,7 +15,7 @@ export function init(
     {
       ...config,
       isStreamable: true,
-      defaultBaseUrl: `${getExternalConfigURL()}/api/v1`,
+      defaultBaseUrl: "https://openrouter.ai/api/v1",
       getPath: () => "/chat/completions",
       getRoutePath: () => "/model",
       endOfStreamSentinel: "[DONE]",


### PR DESCRIPTION
This PR updates the OpenRouter API base URL in the extension's LLM configuration. Changes include:

- Changed `defaultBaseUrl` from using dynamic config URL to direct OpenRouter API endpoint
- Set base URL to `https://openrouter.ai/api/v1`

This change simplifies the API configuration by using the direct OpenRouter endpoint instead of a dynamic configuration URL.